### PR TITLE
Fixed typo in CVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nse-exchange
 
-Nmap NSE scripts to check against exchange vulnerability (CVE-2022-44228).
+Nmap NSE scripts to check against exchange vulnerability (CVE-2022-41082).
 NSE scripts check most popular exposed services on the Internet. It is basic script which checks if virtual patching works.
 
 ### Examples


### PR DESCRIPTION
CVE-2022-44228 in readme should be CVE-2022-41082 (Exchange vuln instead of Log4j2